### PR TITLE
fix potensial bug: when n_importance not divided by up_sample_steps w…

### DIFF
--- a/models/renderer.py
+++ b/models/renderer.py
@@ -319,13 +319,17 @@ class NeuSRenderer:
             with torch.no_grad():
                 pts = rays_o[:, None, :] + rays_d[:, None, :] * z_vals[..., :, None]
                 sdf = self.sdf_network.sdf(pts.reshape(-1, 3)).reshape(batch_size, self.n_samples)
-
+                
                 for i in range(self.up_sample_steps):
+                    _n_importance = self.n_importance // self.up_sample_steps
+                    # add padding to the last step when it is not divisible
+                    if ((i+1) == self.up_sample_steps):
+                        _n_importance += (self.n_importance - (self.n_importance // self.up_sample_steps) * self.up_sample_steps)
                     new_z_vals = self.up_sample(rays_o,
                                                 rays_d,
                                                 z_vals,
                                                 sdf,
-                                                self.n_importance // self.up_sample_steps,
+                                                _n_importance,
                                                 64 * 2**i)
                     z_vals, sdf = self.cat_z_vals(rays_o,
                                                   rays_d,


### PR DESCRIPTION
Potential bug:
in `renderer.py` When `self.n_importance` is not divisible by `self.up_sample_steps` will cause line 365 in `renderer.py` reshape error due to shape differ.

For example when setting `self.up_sample_steps=6` and `self.n_importance=64` and `self.n_samples=64` it will result tensor `sdf`  in last iteration of up sample loop to have shape of `(batch_size,  124)` (since 64//6=10, we missing the non-zero remainder at each loop-iteration) instead of `(batch_size,  128)`.

While in line 341 `n_samples = self.n_samples + self.n_importance`  result 128 instead of 124, so this will make
`s_val = ret_fine['s_val'].reshape(batch_size, n_samples).mean(dim=-1, keepdim=True)`  to cause a reshape error.

I simply add accumulative non-zero reminder to `n_importance` argument passed to `self.up_sample` at last iteration to resolve this bug.
