### PR TITLE
Fixed typo on processing readme

### DIFF
--- a/preprocess_custom_data/readme.md
+++ b/preprocess_custom_data/readme.md
@@ -66,7 +66,7 @@ And you may need to clean it by yourself (here we use Meshlab to clean it manual
 
 ![interest_sparse_points](./static/interest_sparse_points.png)
 
-Save it as `${data_dir}/sparse_point_interest.ply`.
+Save it as `${data_dir}/sparse_points_interest.ply`.
 
 Then run the commands:
 


### PR DESCRIPTION
Fixed typo on readme about preprocessing own data from 'sparse_point_interest.ply' to 'sparse_points_interest.ply'. The first is the current spelling on the readme, but the gen_cameras.py script reads in a file called 'sparse_points_interest.ply' so it won't run if you save the file as 'sparse_point_interest.ply'.