### PR TITLE
fix readme.md in preprocess custom data

### DIFF
--- a/preprocess_custom_data/readme.md
+++ b/preprocess_custom_data/readme.md
@@ -17,7 +17,7 @@ We take the images in `examples/thin_catbus` for example. These images were capt
 Dependencies: 
 
 - cnpy (https://github.com/rogersce/cnpy)
-- OpenCV
+- OpenCV <= 4.6.0
 
 Run commands
 


### PR DESCRIPTION
Aruco preprocess does not work with latest version of OpenCV.
Added that it must be ver.4.6.0 or less.