### PR TITLE
fix typo in preprocess_custom_data readme

### DIFF
--- a/preprocess_custom_data/readme.md
+++ b/preprocess_custom_data/readme.md
@@ -51,7 +51,7 @@ Run  commands
 
 ```
 cd colmap_preprocess
-python img2poses.py ${data_dir}
+python imgs2poses.py ${data_dir}
 ```
 
 After running the commands above, a sparse point cloud is saved in `${data_dir}/sparse_points.ply`.


### PR DESCRIPTION
## Issue

The preprocess_custom_data readme describes the steps to use COLMAP SfM.
In this description is one code-block which includes a typo:

```
cd colmap_preprocess
python img2poses.py ${data_dir}
```

The file `img2poses.py` does not exist, and is actually named `imgs2poses.py`.